### PR TITLE
Parse OSC v1.1 booleans

### DIFF
--- a/osc/bytes-to-osc.rkt
+++ b/osc/bytes-to-osc.rkt
@@ -121,7 +121,13 @@
                             (+ offset 4 len)))
      (values (list 'blob bstr) (round-up-to-4
                                 (+ offset 4 len)))]
-    
+
+    [84 ;; T
+     (values #t offset)]
+
+    [70 ;; F
+     (values #f offset)]
+
     [other
      (error 'read-arg-of-type
             "unimplemented type char: ~v" other)]))
@@ -174,6 +180,12 @@
   (check-equal? (bytes->osc-element 
                  #"/ab/dob\0,bb\0\0\0\0\00512345\0\0\0\0\0\0\00567890\0\0\0")
                 (osc-message #"/ab/dob" `((blob #"12345") (blob #"67890"))))
+
+  (check-equal? (bytes->osc-element #"/true\0\0\0,T\0\0")
+                (osc-message #"/true" (list #t)))
+
+  (check-equal? (bytes->osc-element #"/false\0\0,F\0\0")
+                (osc-message #"/false" (list #f)))
   
   (define test-message-1 (osc-message #"/a/b" (list 257)))
   (define test-message-2 (osc-message #"/z" (list #"woohoo" '(blob #"z"))))


### PR DESCRIPTION
Parses T and F argument types, to Racket values `#t` and `#f` respectively. T and F are already emitted by `osc-element->bytes` when given booleans, but without this patch, `bytes->osc-element` will throw `unimplemented type char: 84` (for T) and `unimplemented type char: 70` (for F) when given an OSC message containing booleans.

Did I handle the `offset` parameter correctly? [The spec](https://opensoundcontrol.stanford.edu/files/2009-NIME-OSC-1.1.pdf) says "No bytes are allocated in the argument data" for these types. It seems to work correctly - I also tested putting booleans in a bundle, and that seemed to parse correctly too.

For the tests, I tried to align the address and message sizes to 4 bytes, and they pass, but I'm also not super confident I padded it correctly.
